### PR TITLE
Fix memory management issues

### DIFF
--- a/src/benzina/bcachefs/bcachefsmodule.c
+++ b/src/benzina/bcachefs/bcachefsmodule.c
@@ -184,22 +184,20 @@ static PyObject* PyBCacheFS_iterator_new(PyTypeObject* type, PyObject* args, PyO
 
 static PyObject *PyBCacheFS_iterator_next(PyBCacheFS_iterator *self)
 {
-    PyTupleObject *ret = (PyTupleObject*)Py_None;
     const BCacheFS *fs = &self->_pyfs->_fs;
     BCacheFS_iterator *iter = &self->_iter;
     const struct bch_val *bch_val = BCacheFS_iter_next(fs, iter);
     if (bch_val && iter->type == BTREE_ID_extents)
     {
         BCacheFS_extent extent = BCacheFS_iter_make_extent(fs, iter);
-        ret = (PyTupleObject*)Py_BuildValue("KKKK", extent.inode, extent.file_offset, extent.offset, extent.size);
+        return Py_BuildValue("KKKK", extent.inode, extent.file_offset, extent.offset, extent.size);
     }
     else if (bch_val && iter->type == BTREE_ID_dirents)
     {
         BCacheFS_dirent dirent = BCacheFS_iter_make_dirent(fs, iter);
-        ret = (PyTupleObject*)Py_BuildValue("KKIU", dirent.parent_inode, dirent.inode, (uint32_t)dirent.type, dirent.name);
+        return Py_BuildValue("KKIU", dirent.parent_inode, dirent.inode, (uint32_t)dirent.type, dirent.name);
     }
-    Py_INCREF(ret);
-    return (PyObject*)ret;
+    return Py_None;
 }
 
 /**


### PR DESCRIPTION
Fix leak of superblock realloc when an out-of-place malloc fails
Fix access of unitialized superblock memory when reading the superblock for the first time
Fix over incrementation of reference count for PyBCacheFS_iterator_next's tuples