### PR TITLE
Fix Python 3.7

### DIFF
--- a/.github/workflows/bcachefs-test.yml
+++ b/.github/workflows/bcachefs-test.yml
@@ -4,7 +4,11 @@ on: [push, pull_request]
 
 jobs:
   bchfs-compile:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-latest]
+        python-version: ['3.7', '3.8']
 
     steps:
       - uses: actions/checkout@v1
@@ -12,10 +16,10 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Requirements
         run: |

--- a/tests/benzina/bcachefs/test_bcachefs_file.py
+++ b/tests/benzina/bcachefs/test_bcachefs_file.py
@@ -74,10 +74,12 @@ def test_file_read1(size):
             sha = sha256()
 
             k = 0
-            while data := saved.read1(size):
+            data = saved.read1(size)
+            while data:
                 all_data.append(data)
                 k += 1
                 sha.update(data)
+                data = saved.read1(size)
 
             bcachefs_hash = sha.digest()
 
@@ -98,8 +100,10 @@ def test_file_readinto1(size):
             sha = sha256()
 
             buffer = bytearray(size)
-            while size := saved.readinto1(buffer):
+            size = saved.readinto1(buffer)
+            while size:
                 sha.update(buffer[:size])
+                size = saved.readinto1(buffer)
 
             bcachefs_hash = sha.digest()
 


### PR DESCRIPTION
Follow up from #19 

Not adding support for Py 3.6 yet as we use some Py 3.7 C types.

From log with Py 3.6:
```
Run python setup.py -coverage develop
Compiling with coverage
running develop
running egg_info
creating bcachefs.egg-info
writing bcachefs.egg-info/PKG-INFO
writing dependency_links to bcachefs.egg-info/dependency_links.txt
writing top-level names to bcachefs.egg-info/top_level.txt
writing manifest file 'bcachefs.egg-info/SOURCES.txt'
reading manifest file 'bcachefs.egg-info/SOURCES.txt'
writing manifest file 'bcachefs.egg-info/SOURCES.txt'
running build_ext
building 'bcachefs.c_bcachefs' extension
creating build
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/bcachefs
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ibcachefs/ -I/opt/hostedtoolcache/Python/3.6.15/x64/include/python3.6m -c bcachefs/bcachefs.c -o build/temp.linux-x86_64-3.6/bcachefs/bcachefs.o -coverage -g3 -O0
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ibcachefs/ -I/opt/hostedtoolcache/Python/3.6.15/x64/include/python3.6m -c bcachefs/bcachefsmodule.c -o build/temp.linux-x86_64-3.6/bcachefs/bcachefsmodule.o -coverage -g3 -O0
bcachefs/bcachefsmodule.c:101:28: error: ‘_PyCFunctionFastWithKeywords’ undeclared here (not in a function); did you mean ‘_PyCFunction_FastCallKeywords’?
  101 |     {"open", (PyCFunction)(_PyCFunctionFastWithKeywords)PyBcachefs_open,
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            _PyCFunction_FastCallKeywords
bcachefs/bcachefsmodule.c:101:57: error: expected ‘}’ before ‘PyBcachefs_open’
  101 |     {"open", (PyCFunction)(_PyCFunctionFastWithKeywords)PyBcachefs_open,
      |     ~                                                   ^~~~~~~~~~~~~~~
bcachefs/bcachefsmodule.c:104:57: error: expected ‘}’ before ‘PyBcachefs_iter’
  104 |     {"iter", (PyCFunction)(_PyCFunctionFastWithKeywords)PyBcachefs_iter,
      |     ~                                                   ^~~~~~~~~~~~~~~
bcachefs/bcachefsmodule.c:67:18: warning: ‘PyBcachefs_iter’ defined but not used [-Wunused-function]
   67 | static PyObject *PyBcachefs_iter(PyBcachefs *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
      |                  ^~~~~~~~~~~~~~~
bcachefs/bcachefsmodule.c:36:18: warning: ‘PyBcachefs_open’ defined but not used [-Wunused-function]
   36 | static PyObject *PyBcachefs_open(PyBcachefs *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
      |                  ^~~~~~~~~~~~~~~
error: command 'gcc' failed with exit status 1
Error: Process completed with exit code 1.
```