### PR TITLE
Fix long bkeys sequence spread over multiple btrees

### DIFF
--- a/.github/workflows/bcachefs-test.yml
+++ b/.github/workflows/bcachefs-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-20.04, ubuntu-latest]
         python-version: ['3.7', '3.8']
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ bcachefs_module = Extension(
 
 setup(
     name="bcachefs",
-    version="0.1.12",
+    version="0.1.13",
     author="Satya Ortiz-Gagné",
     description="Fast Disk Image for HPC",
     long_description=open("README.rst").read(),


### PR DESCRIPTION
some bkeys sequence (like extents of large files) can be contained in multiple btrees